### PR TITLE
Don't make unnecessary test

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ describe("Dynamic folder test", function () {
         // Called before any of the tests are run
     });
 
-    // `after` is also called before the tests are run, but after the `before`
-    // `beforeEach` and `afterEach` do not work as expected
+    beforeEach(function () {
+        // Called before each test is run
+    });
 
     testFolder<Input, Output, Error>(
         "Suite Name",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "Braxton Hall"
     ],
     "license": "GPL-3.0",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "build/index.js",
     "types": "build/index.d.ts",
     "engines": {

--- a/src/testFolder.ts
+++ b/src/testFolder.ts
@@ -4,12 +4,12 @@ import {expect} from "chai";
 import {joinWithDefaultOptions} from "./Options";
 import {readTestsFromDisk} from "./readTestsFromDisk";
 import {validateTests} from "./validateTests";
-import {ITest} from "mocha";
+import {ISuite} from "mocha";
 
 function testFolder<I, O, E>(suiteName: string,
                              target: (input: I) => O | PromiseLike<O>,
                              folder: string,
-                             options: Partial<TestFolderOptions<I, O, E>> = {}): ITest {
+                             options: Partial<TestFolderOptions<I, O, E>> = {}): ISuite {
 
     const mergedOptions = joinWithDefaultOptions(options);
     let tests: Array<TestFolderSchemaWithFilename<I, O, E>>;
@@ -23,31 +23,28 @@ function testFolder<I, O, E>(suiteName: string,
     }
 
     // Dynamically create and run a test for each query in testQueries
-    // Creates an extra "test" called "Should run dynamic tests" as a byproduct. Don't worry about it
-    return it("Should run dynamic tests", function () {
-        describe(suiteName, function () {
-            for (const test of tests) {
-                it(`[${test.filename}] ${test.title}`, async function () {
-                    try {
-                        // O could be a promise or not, this abstracts that away for us
-                        const result = await target(test.input);
-                        if (test.errorExpected) {
-                            // if we want an error just reject again
-                            return Promise.reject(new Error(`Expected an error but instead resolved or returned with ${result}`));
-                        } else if (test.with !== undefined) {
-                            return mergedOptions.assertOnResult(test.with as O, result);
-                        }
-                    } catch (err) {
-                        if (!test.errorExpected) {
-                            // if we don't want an error just rethrow
-                            throw err;
-                        } else if (test.with !== undefined) {
-                            return mergedOptions.assertOnError(test.with as E, err);
-                        }
+    return describe(suiteName, function () {
+        for (const test of tests) {
+            it(`[${test.filename}] ${test.title}`, async function () {
+                try {
+                    // O could be a promise or not, this abstracts that away for us
+                    const result = await target(test.input);
+                    if (test.errorExpected) {
+                        // if we want an error just reject again
+                        return Promise.reject(new Error(`Expected an error but instead resolved or returned with ${result}`));
+                    } else if (test.with !== undefined) {
+                        return mergedOptions.assertOnResult(test.with as O, result);
                     }
-                });
-            }
-        });
+                } catch (err) {
+                    if (!test.errorExpected) {
+                        // if we don't want an error just rethrow
+                        throw err;
+                    } else if (test.with !== undefined) {
+                        return mergedOptions.assertOnError(test.with as E, err);
+                    }
+                }
+            });
+        }
     });
 }
 


### PR DESCRIPTION
The boilerplate this was ~~stolen from~~ _inspired by_ used the `before` function, which is why the describe was wrapped up in an `it`. We don't use that, so let's just not make the extra test