### PR TITLE
3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,12 +127,12 @@ function folderTest<I, O, E>(suiteName: string, target: (input: I) => O, path: s
 interface Options {
     // The function that will be called on the result of the code under test
     // if errorExpected is false and the code under test does not throw
-    //  if absent, defaults to `expect(actual).to.deep.equal(expected)`
+    //  if absent, only asserts that the code under test does not throw
     assertOnResult?: (actual: any, expected: Awaited<O>, input: I) => void | PromiseLike<void>;
 
     // The function that will be called on the result of the code under test
     // if errorExpected is true and the code under test throws
-    //  if absent, defaults to `expect(actual).to.deep.equal(expected)`
+    //  if absent, only asserts that the code under test throws
     assertOnError?: (actual: any, expected: E, input: I) => void | PromiseLike<void>;
 
     // Called on the JSON files to ensure that the inputs are "correct" as specified this function

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ describe("Dynamic folder test", function () {
     });
     
     // Assert value equals expected
-    function assertResult(actual: any, expected: Output): void {
+    function assertResult(actual: unknown, expected: Output): void {
         expect(actual).to.equal(expected);
     }
 
     // Assert actual error is of expected type
-    function assertError(actual: any, expected: Error): void {
+    function assertError(actual: unknown, expected: Error): void {
         if (expected === "RedError") {
             expect(actual).to.be.an.instanceOf(RedError);
         } else {
@@ -128,24 +128,24 @@ interface Options {
     // The function that will be called on the result of the code under test
     // if errorExpected is false and the code under test does not throw
     //  if absent, only asserts that the code under test does not throw
-    assertOnResult?: (actual: any, expected: O, input: I) => void | PromiseLike<void>;
+    assertOnResult?: (actual: unknown, expected: O, input: I) => void | PromiseLike<void>;
 
     // The function that will be called on the result of the code under test
     // if errorExpected is true and the code under test throws
     //  if absent, only asserts that the code under test throws
-    assertOnError?: (actual: any, expected: E, input: I) => void | PromiseLike<void>;
+    assertOnError?: (actual: unknown, expected: E, input: I) => void | PromiseLike<void>;
 
     // Called on the JSON files to ensure that the inputs are "correct" as specified this function
     //  if absent, the inputs are not validated
-    inputValidator?: (input: any) => input is I;
+    inputValidator?: (input: unknown) => input is I;
 
     // Called on the JSON files to ensure that the outputs are "correct" as specified this function
     //  if absent, the outputs are not validated
-    outputValidator?: (output: any) => output is O;
+    outputValidator?: (output: unknown) => output is O;
 
     // Called on the JSON files to ensure that the errors are "correct" as specified this function
     //  if absent, the errors are not validated
-    errorValidator?: (error: any) => error is E;
+    errorValidator?: (error: unknown) => error is E;
 
     // Whether or not to check the JSON for extraneous keys
     // Useful if you are prone to typos

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Assert error
  * @param path - A path where the json schemata are located (includes json schemata in subdirectories)
  * @param options - Described below
  */
-function folderTest<I, O, E>(suiteName: string, target: (input: I) => O, path: string, options: Options) {
+function folderTest<I, O, E>(suiteName: string, target: (input: I) => unknown, path: string, options: Options) {
     // ...
 }
 
@@ -128,7 +128,7 @@ interface Options {
     // The function that will be called on the result of the code under test
     // if errorExpected is false and the code under test does not throw
     //  if absent, only asserts that the code under test does not throw
-    assertOnResult?: (actual: any, expected: Awaited<O>, input: I) => void | PromiseLike<void>;
+    assertOnResult?: (actual: any, expected: O, input: I) => void | PromiseLike<void>;
 
     // The function that will be called on the result of the code under test
     // if errorExpected is true and the code under test throws
@@ -174,6 +174,6 @@ interface FolderTestSchema<I, O, E> {
 
     // The value that code under test must equal
     //  if absent, will only test that the code under test does/doesn't throw an error
-    expected?: Awaited<O> | E;
+    expected?: O | E;
 }
 ```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "Braxton Hall"
     ],
     "license": "GPL-3.0",
-    "version": "2.0.1",
+    "version": "3.0.0",
     "main": "build/index.js",
     "types": "build/index.d.ts",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "@typescript-eslint/eslint-plugin": "5.9.0",
         "@typescript-eslint/eslint-plugin-tslint": "5.9.0",
         "@typescript-eslint/parser": "5.9.0",
+        "chai": "4.3.4",
         "eslint": "8.6.0",
         "nyc": "15.1.0",
         "ts-node": "10.2.1",
@@ -28,7 +29,6 @@
         "typescript": "4.5.4"
     },
     "dependencies": {
-        "chai": "4.3.4",
         "fs-extra": "10.0.0",
         "mocha": "9.1.0"
     },

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -1,12 +1,11 @@
-import {expect} from "chai";
 import {FolderTestOptions} from "./types";
 
-function assertOnResult<O>(actual: any, expected: Awaited<O>): void {
-    expect(actual).to.deep.equal(expected);
+function assertOnResult(): void {
+    // Assert nothing
 }
 
-function assertOnError<E>(actual: any, expected: E): void {
-    expect(actual).to.deep.equal(expected);
+function assertOnError(): void {
+    // Assert nothing
 }
 
 function getDefaultOptions<I, O, E>(): FolderTestOptions<I, O, E> {

--- a/src/folderTest.ts
+++ b/src/folderTest.ts
@@ -7,7 +7,7 @@ import {validateTests} from "./validateTests";
 import {Suite} from "mocha";
 
 function folderTest<I, O, E>(suiteName: string,
-                             target: (input: I) => O,
+                             target: (input: I) => unknown,
                              folder: string,
                              options: Partial<FolderTestOptions<I, O, E>> = {}): Suite {
 
@@ -34,7 +34,7 @@ function folderTest<I, O, E>(suiteName: string,
                         const supplement = test.verbose ? ` with ${result}` : "";
                         return Promise.reject(new Error(`Expected an error but instead resolved or returned${supplement}`));
                     } else if (test.expected !== undefined) {
-                        return mergedOptions.assertOnResult(result, test.expected as Awaited<O>, test.input);
+                        return mergedOptions.assertOnResult(result, test.expected as O, test.input);
                     }
                 } catch (err) {
                     if (!test.errorExpected) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,10 @@
 export interface FolderTestOptions<I, O, E> {
-    assertOnResult: (actual: any, expected: O, input: I) => void | PromiseLike<void>;
-    assertOnError: (actual: any, expected: E, input: I) => void | PromiseLike<void>;
+    assertOnResult: (actual: unknown, expected: O, input: I) => void | PromiseLike<void>;
+    assertOnError: (actual: unknown, expected: E, input: I) => void | PromiseLike<void>;
     checkForExcessKeys: boolean;
-    inputValidator?: (input: any) => input is I;
-    outputValidator?: (output: any) => output is O;
-    errorValidator?: (error: any) => error is E;
+    inputValidator?: (input: unknown) => input is I;
+    outputValidator?: (output: unknown) => output is O;
+    errorValidator?: (error: unknown) => error is E;
 }
 
 export interface FolderTestSchema<I, O, E> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
 export interface FolderTestOptions<I, O, E> {
-    assertOnResult: (actual: any, expected: Awaited<O>, input: I) => void | PromiseLike<void>;
+    assertOnResult: (actual: any, expected: O, input: I) => void | PromiseLike<void>;
     assertOnError: (actual: any, expected: E, input: I) => void | PromiseLike<void>;
     checkForExcessKeys: boolean;
     inputValidator?: (input: any) => input is I;
-    outputValidator?: (output: any) => output is Awaited<O>;
+    outputValidator?: (output: any) => output is O;
     errorValidator?: (error: any) => error is E;
 }
 
@@ -12,7 +12,7 @@ export interface FolderTestSchema<I, O, E> {
     input: I;
     errorExpected?: boolean;
     verbose?: boolean;
-    expected?: Awaited<O> | E; // if an error is expected this MUST be E otherwise it must be O
+    expected?: O | E; // if an error is expected this MUST be E otherwise it must be O
 }
 
 export interface FolderTestSchemaWithFilename<I, O, E> extends FolderTestSchema<I, O, E> {


### PR DESCRIPTION
- [x] Default assertions are arbitrary and just shouldn't be there -- remove them
- [x] Code under test's `O` should be decoupled from Schema `O` like the `E`s
- [x] resolves #26 

##

- [x] Wait until the end of term because these are all breaking changes