### PR TITLE
Migrate package to ubccpsc310/ for easier package maintenance.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,17 @@
 {
     "name": "@ubccpsc310/folder-test",
     "description": "Load many tests from a folder",
-    "homepage": "https://github.com/falkirks/folder-test",
+    "homepage": "https://github.com/ubccpsc310/folder-test",
     "contributors": [
         "Noa Heyl",
         "Braxton Hall"
     ],
     "license": "GPL-3.0",
-    "version": "3.0.0",
+    "version": "3.0.1",
+    "repository": {
+        "type": "git",
+        "url": "git@github.com:ubccpsc310/folder-test.git"
+    },
     "main": "build/index.js",
     "types": "build/index.d.ts",
     "engines": {


### PR DESCRIPTION
Hi @falkirks! We're hoping to migrate this package to `ubccpsc310/` so we can update it without having to bother you. I think (hope?) this will make this possible.

(We're following the instructions here: https://github.com/orgs/community/discussions/8577#discussioncomment-9823877)

Thanks so much for your help!